### PR TITLE
close the file after output so it doesn't get stuck

### DIFF
--- a/src/main/groovy/com/selesse/gradle/git/changelog/tasks/GenerateChangelogTask.groovy
+++ b/src/main/groovy/com/selesse/gradle/git/changelog/tasks/GenerateChangelogTask.groovy
@@ -54,7 +54,11 @@ class GenerateChangelogTask extends DefaultTask {
             getOutputDirectory().mkdirs()
             def changelogFile = getOutputFile(format)
 
-            changelogWriter.writeChangelog(new PrintStream(new FileOutputStream(changelogFile)))
+
+            def fileOutputStream = new FileOutputStream(changelogFile)
+            changelogWriter.writeChangelog(new PrintStream(fileOutputStream))
+            fileOutputStream.close()
+            changelogFile.close()
         }
     }
 


### PR DESCRIPTION
Fix the error 
java.io.IOException: Unable to delete file: E:\proyectos\tr2\tr2-web\build\resources\main\changelog.md